### PR TITLE
Fix default FS_LISTEN_PATH + sort proofs + date format + other fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,14 +314,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
- "windows-link",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1138,6 +1133,7 @@ dependencies = [
 name = "kholles_server"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "comrak",
  "gray_matter",
  "hex",
@@ -2723,7 +2719,7 @@ checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result",
  "windows-strings",
 ]
@@ -2757,12 +2753,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -2771,7 +2773,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = "0.4.42"
 comrak = "0.39.0"
 gray_matter = "0.2.8"
 hex = "0.4.3"

--- a/src/list_fs.rs
+++ b/src/list_fs.rs
@@ -106,7 +106,7 @@ fn list_weeks(
 pub fn get_proof_list() -> Result<HashMap<<Proof as ProofTrait>::ProofIdType, Proof>, CustomError> {
     let mut files = HashMap::new();
     list_proofs(
-        Path::new(&env::var(LISTEN_PATH_ENV_NAME).unwrap_or(".".to_string()))
+        Path::new(&env::var(LISTEN_PATH_ENV_NAME).unwrap_or("content".to_string()))
             .join(PROOF_SUBFOLDER_NAME)
             .as_path(),
         &mut files,
@@ -116,7 +116,7 @@ pub fn get_proof_list() -> Result<HashMap<<Proof as ProofTrait>::ProofIdType, Pr
 pub fn get_week_list() -> Result<HashMap<<Week as WeekTrait>::WeekNumberType, Week>, CustomError> {
     let mut weeks = HashMap::new();
     list_weeks(
-        Path::new(&env::var(LISTEN_PATH_ENV_NAME).unwrap_or(".".to_string()))
+        Path::new(&env::var(LISTEN_PATH_ENV_NAME).unwrap_or("content".to_string()))
             .join(WEEK_SUBFOLDER_NAME)
             .as_path(),
         &mut weeks,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn proof_list_endpoint() -> Result<Template, CustomError> {
     Ok(Template::render(
         "proof-list",
         context! {
-            proofs: files.into_values().map(|e| e.clone()).collect::<Vec<Proof>>(),
+            proofs: files.into_values().map(|e| e.clone()).collect::<Vec<Proof>>().sort(),
         },
     ))
 }
@@ -67,7 +67,7 @@ fn week_list_endpoint() -> Result<Template, CustomError> {
 fn week_newest_endpoint() -> Result<Template, CustomError> {
     let weeks = get_week_list()?;
 
-    let mut week_list = weeks.values().map(|e| e.clone()).collect::<Vec<Week>>();
+    let week_list = weeks.values().map(|e| e.clone()).collect::<Vec<Week>>();
     let newest = week_list
         .iter()
         .max_by_key(|w| w.number)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,16 @@ fn index_endpoint() -> Result<Template, CustomError> {
 fn proof_list_endpoint() -> Result<Template, CustomError> {
     let files = get_proof_list()?;
 
+    let mut proofs = files
+        .into_values()
+        .map(|e| e.clone())
+        .collect::<Vec<Proof>>();
+    proofs.sort_unstable();
+
     Ok(Template::render(
         "proof-list",
         context! {
-            proofs: files.into_values().map(|e| e.clone()).collect::<Vec<Proof>>().sort(),
+            proofs,
         },
     ))
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,7 @@ pub trait ProofTrait {
 }
 
 impl ProofTrait for Proof {
-    type ProofIdType = u32;
+    type ProofIdType = u64;
 }
 
 impl PartialOrd for Proof {


### PR DESCRIPTION
According to the README the default `FS_LISTEN_PATH` should be set to `content` and not `.`